### PR TITLE
Use just one header for Link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 0.2.1 - TBD
+
+### Added
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Fixed a problem where multiple headers can't be sent.  
+  Now a single Link header will be sent with all values.
+
+
 ## 0.2.0 - 2017-12-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ In your template:
 
 ### Response headers
 
-The module will automatically add headers to the response with these links (or similar):
+The module will automatically add a Link header to the response:
 
 ```
-Link: </assets/images/logo.png>; rel="preload"; as="image"; media="image/png"
-Link: </assets/vendor.css>; rel="preload"; as="style"
-Link: </assets/vendor.js>; rel="preload"; as="script"
-Link: </assets/next.css>; rel="prefetch"; as="style"
+Link: </assets/images/logo.png>; rel="preload"; as="image"; media="image/png",
+  </assets/vendor.css>; rel="preload"; as="style",
+  </assets/vendor.js>; rel="preload"; as="script",
+  </assets/next.css>; rel="prefetch"; as="style"
 ```
 
 You should notice that resource `/script/foo.js` is not in headers, because it wasn't
@@ -148,7 +148,7 @@ In your template:
 
 ### Response headers
 
-The module will automatically add headers to the response with these links:
+The module will automatically add a Link header to the response:
 
 ```
 Link: </assets/vendor.css>; rel="preload"; as="style"; type="text/css"; media="screen"
@@ -198,11 +198,11 @@ In your template:
 
 ### Response headers
 
-The module will automatically add headers to the response with these links:
+The module will automatically add a Link header to the response:
 
 ```
-Link: </script/foo.js>; rel="preload"; as="script"; type="text/javascript"
-Link: </script/bar.js>; rel="preload"; as="script"; type="text/foo"
+Link: </script/foo.js>; rel="preload"; as="script"; type="text/javascript",
+  </script/bar.js>; rel="preload"; as="script"; type="text/foo"
 ```
 
 

--- a/src/Listener/LinkHandler.php
+++ b/src/Listener/LinkHandler.php
@@ -57,6 +57,8 @@ final class LinkHandler extends AbstractLinkHandler
             return;
         }
 
+        $values = [];
+
         foreach ($this->headLink->getContainer() as $item) {
             $attributes = \get_object_vars($item);
 
@@ -68,8 +70,10 @@ final class LinkHandler extends AbstractLinkHandler
                 $attributes['nopush'] = null;
             }
 
-            $response->getHeaders()->addHeader($this->createLinkHeader($attributes));
+            $values[] = $this->createLinkHeaderValue($attributes);
         }
+
+        $this->addLinkHeader($response, $values);
     }
 
     /**

--- a/src/Listener/ScriptHandler.php
+++ b/src/Listener/ScriptHandler.php
@@ -53,6 +53,8 @@ final class ScriptHandler extends AbstractLinkHandler
             return;
         }
 
+        $values = [];
+
         foreach ($this->headScript->getContainer() as $item) {
             $properties = \get_object_vars($item);
             $attributes = $properties['attributes'] ?? [];
@@ -74,8 +76,10 @@ final class ScriptHandler extends AbstractLinkHandler
                 $attributes['nopush'] = null;
             }
 
-            $response->getHeaders()->addHeader($this->createLinkHeader($attributes));
+            $values[] = $this->createLinkHeaderValue($attributes);
         }
+
+        $this->addLinkHeader($response, $values);
     }
 
     /**

--- a/src/Listener/StylesheetHandler.php
+++ b/src/Listener/StylesheetHandler.php
@@ -54,6 +54,8 @@ final class StylesheetHandler extends AbstractLinkHandler
             return;
         }
 
+        $values = [];
+
         foreach ($this->headLink->getContainer() as $item) {
             $attributes = \get_object_vars($item);
 
@@ -78,8 +80,10 @@ final class StylesheetHandler extends AbstractLinkHandler
                 $attributes['nopush'] = null;
             }
 
-            $response->getHeaders()->addHeader($this->createLinkHeader($attributes));
+            $values[] = $this->createLinkHeaderValue($attributes);
         }
+
+        $this->addLinkHeader($response, $values);
     }
 
     /**

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -6,9 +6,6 @@ namespace Facile\ZFLinkHeadersModule\Functional;
 
 use Facile\ZFLinkHeadersModule\Options;
 use Facile\ZFLinkHeadersModule\OptionsInterface;
-use PHPUnit\Framework\ExpectationFailedException;
-use Zend\Http\Header\HeaderInterface;
-use Zend\Http\Headers;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
 
@@ -29,14 +26,12 @@ class FunctionalTest extends AbstractHttpControllerTestCase
     public function testIndexActionWithDefaultOptions()
     {
         $this->dispatch('/');
-        // Links
-        $this->assertResponseHeaderContains('Link', '</style/foo.css>; rel="preload"');
-        $this->assertResponseHeaderContains('Link', '</style/bar.css>; rel="prefetch"; as="style"; type="text/stylesheet"');
-        // Stylesheets
-        $this->assertNotResponseHeaderContains('Link', '</style/stylesheet.css>; rel="preload"; as="style"; type="text/css"; media="screen"');
-        // Scripts
-        $this->assertNotResponseHeaderContains('Link', '</script/foo.js>; rel="preload"; as="script"; type="text/javascript"');
-        $this->assertNotResponseHeaderContains('Link', '</script/bar.js>; rel="preload"; as="script"; type="text/text"');
+
+        $expected = [
+            '</style/foo.css>; rel="preload"',
+            '</style/bar.css>; rel="prefetch"; as="style"; type="text/stylesheet"',
+        ];
+        $this->assertResponseHeaderContains('Link', \implode(', ', $expected));
     }
 
     /**
@@ -46,20 +41,18 @@ class FunctionalTest extends AbstractHttpControllerTestCase
     {
         /** @var ServiceManager $serviceManager */
         $serviceManager = $this->getApplication()->getServiceManager();
-        $serviceManager->setAllowOverride(true);
         /** @var Options $options */
         $options = $serviceManager->get(OptionsInterface::class);
         $options->setStylesheetEnabled(true);
 
         $this->dispatch('/');
-        // Links
-        $this->assertResponseHeaderContains('Link', '</style/foo.css>; rel="preload"');
-        $this->assertResponseHeaderContains('Link', '</style/bar.css>; rel="prefetch"; as="style"; type="text/stylesheet"');
-        // Stylesheets
-        $this->assertResponseHeaderContains('Link', '</style/stylesheet.css>; rel="preload"; as="style"; type="text/css"; media="screen"');
-        // Scripts
-        $this->assertNotResponseHeaderContains('Link', '</script/foo.js>; rel="preload"; as="script"; type="text/javascript"');
-        $this->assertNotResponseHeaderContains('Link', '</script/bar.js>; rel="preload"; as="script"; type="text/text"');
+
+        $expected = [
+            '</style/foo.css>; rel="preload"',
+            '</style/bar.css>; rel="prefetch"; as="style"; type="text/stylesheet"',
+            '</style/stylesheet.css>; rel="preload"; as="style"; type="text/css"; media="screen"',
+        ];
+        $this->assertResponseHeaderContains('Link', \implode(', ', $expected));
     }
 
     /**
@@ -69,21 +62,19 @@ class FunctionalTest extends AbstractHttpControllerTestCase
     {
         /** @var ServiceManager $serviceManager */
         $serviceManager = $this->getApplication()->getServiceManager();
-        $serviceManager->setAllowOverride(true);
         /** @var Options $options */
         $options = $serviceManager->get(OptionsInterface::class);
         $options->setStylesheetEnabled(true);
         $options->setStylesheetMode('prefetch');
 
         $this->dispatch('/');
-        // Links
-        $this->assertResponseHeaderContains('Link', '</style/foo.css>; rel="preload"');
-        $this->assertResponseHeaderContains('Link', '</style/bar.css>; rel="prefetch"; as="style"; type="text/stylesheet"');
-        // Stylesheets
-        $this->assertResponseHeaderContains('Link', '</style/stylesheet.css>; rel="prefetch"; as="style"; type="text/css"; media="screen"');
-        // Scripts
-        $this->assertNotResponseHeaderContains('Link', '</script/foo.js>; rel="preload"; as="script"; type="text/javascript"');
-        $this->assertNotResponseHeaderContains('Link', '</script/bar.js>; rel="preload"; as="script"; type="text/text"');
+
+        $expected = [
+            '</style/foo.css>; rel="preload"',
+            '</style/bar.css>; rel="prefetch"; as="style"; type="text/stylesheet"',
+            '</style/stylesheet.css>; rel="prefetch"; as="style"; type="text/css"; media="screen"',
+        ];
+        $this->assertResponseHeaderContains('Link', \implode(', ', $expected));
     }
 
     /**
@@ -93,20 +84,19 @@ class FunctionalTest extends AbstractHttpControllerTestCase
     {
         /** @var ServiceManager $serviceManager */
         $serviceManager = $this->getApplication()->getServiceManager();
-        $serviceManager->setAllowOverride(true);
         /** @var Options $options */
         $options = $serviceManager->get(OptionsInterface::class);
         $options->setScriptEnabled(true);
 
         $this->dispatch('/');
-        // Links
-        $this->assertResponseHeaderContains('Link', '</style/foo.css>; rel="preload"');
-        $this->assertResponseHeaderContains('Link', '</style/bar.css>; rel="prefetch"; as="style"; type="text/stylesheet"');
-        // Stylesheets
-        $this->assertNotResponseHeaderContains('Link', '</style/stylesheet.css>; rel="preload"; as="style"; type="text/css"; media="screen"');
-        // Scripts
-        $this->assertResponseHeaderContains('Link', '</script/foo.js>; rel="preload"; as="script"; type="text/javascript"');
-        $this->assertResponseHeaderContains('Link', '</script/bar.js>; rel="preload"; as="script"; type="text/text"');
+
+        $expected = [
+            '</style/foo.css>; rel="preload"',
+            '</style/bar.css>; rel="prefetch"; as="style"; type="text/stylesheet"',
+            '</script/foo.js>; rel="preload"; as="script"; type="text/javascript"',
+            '</script/bar.js>; rel="preload"; as="script"; type="text/text"',
+        ];
+        $this->assertResponseHeaderContains('Link', \implode(', ', $expected));
     }
 
     /**
@@ -116,21 +106,20 @@ class FunctionalTest extends AbstractHttpControllerTestCase
     {
         /** @var ServiceManager $serviceManager */
         $serviceManager = $this->getApplication()->getServiceManager();
-        $serviceManager->setAllowOverride(true);
         /** @var Options $options */
         $options = $serviceManager->get(OptionsInterface::class);
         $options->setScriptEnabled(true);
         $options->setScriptMode('prefetch');
 
         $this->dispatch('/');
-        // Links
-        $this->assertResponseHeaderContains('Link', '</style/foo.css>; rel="preload"');
-        $this->assertResponseHeaderContains('Link', '</style/bar.css>; rel="prefetch"; as="style"; type="text/stylesheet"');
-        // Stylesheets
-        $this->assertNotResponseHeaderContains('Link', '</style/stylesheet.css>; rel="prefetch"; as="style"; type="text/css"; media="screen"');
-        // Scripts
-        $this->assertResponseHeaderContains('Link', '</script/foo.js>; rel="prefetch"; as="script"; type="text/javascript"');
-        $this->assertResponseHeaderContains('Link', '</script/bar.js>; rel="prefetch"; as="script"; type="text/text"');
+
+        $expected = [
+            '</style/foo.css>; rel="preload"',
+            '</style/bar.css>; rel="prefetch"; as="style"; type="text/stylesheet"',
+            '</script/foo.js>; rel="prefetch"; as="script"; type="text/javascript"',
+            '</script/bar.js>; rel="prefetch"; as="script"; type="text/text"',
+        ];
+        $this->assertResponseHeaderContains('Link', \implode(', ', $expected));
     }
 
     /**
@@ -140,7 +129,6 @@ class FunctionalTest extends AbstractHttpControllerTestCase
     {
         /** @var ServiceManager $serviceManager */
         $serviceManager = $this->getApplication()->getServiceManager();
-        $serviceManager->setAllowOverride(true);
         /** @var Options $options */
         $options = $serviceManager->get(OptionsInterface::class);
         $options->setScriptEnabled(true);
@@ -148,89 +136,14 @@ class FunctionalTest extends AbstractHttpControllerTestCase
         $options->setHttp2PushEnabled(false);
 
         $this->dispatch('/');
-        // Links
-        $this->assertResponseHeaderContains('Link', '</style/foo.css>; rel="preload"; nopush');
-        $this->assertResponseHeaderContains('Link', '</style/bar.css>; rel="prefetch"; as="style"; type="text/stylesheet"; nopush');
-        // Stylesheets
-        $this->assertResponseHeaderContains('Link', '</style/stylesheet.css>; rel="preload"; as="style"; type="text/css"; media="screen"; nopush');
-        // Scripts
-        $this->assertResponseHeaderContains('Link', '</script/foo.js>; rel="preload"; as="script"; type="text/javascript"; nopush');
-        $this->assertResponseHeaderContains('Link', '</script/bar.js>; rel="preload"; as="script"; type="text/text"; nopush');
-    }
 
-    /**
-     * Assert response header exists and contains the given string
-     *
-     * @param  string $header
-     * @param  string $match
-     */
-    public function assertResponseHeaderContains($header, $match)
-    {
-        $responseHeader = $this->getResponseHeader($header);
-        if (! $responseHeader) {
-            throw new ExpectationFailedException($this->createFailureMessage(sprintf(
-                'Failed asserting response header, header "%s" doesn\'t exist',
-                $header
-            )));
-        }
-
-        $response = $this->getResponse();
-        /** @var Headers|HeaderInterface[] $headers */
-        $headers = $response->getHeaders();
-
-        $headerMatched = false;
-        $currentHeader = null;
-
-        foreach ($headers as $currentHeader) {
-            if ($match === $currentHeader->getFieldValue()) {
-                $headerMatched = true;
-                break;
-            }
-        }
-
-        if (! $headerMatched) {
-            throw new ExpectationFailedException($this->createFailureMessage(sprintf(
-                'Failed asserting response header "%s" exists and contains "%s"',
-                $header,
-                $match
-            )));
-        }
-
-        $this->assertEquals($match, $currentHeader ? $currentHeader->getFieldValue() : null);
-    }
-
-    /**
-     * Assert response header exists and contains the given string
-     *
-     * @param  string $header
-     * @param  string $match
-     */
-    public function assertNotResponseHeaderContains($header, $match)
-    {
-        $responseHeader = $this->getResponseHeader($header);
-        if (! $responseHeader) {
-            throw new ExpectationFailedException($this->createFailureMessage(sprintf(
-                'Failed asserting response header, header "%s" doesn\'t exist',
-                $header
-            )));
-        }
-
-        $response = $this->getResponse();
-        /** @var Headers|HeaderInterface[] $headers */
-        $headers = $response->getHeaders();
-
-        $currentHeader = null;
-
-        foreach ($headers as $currentHeader) {
-            if ($match === $currentHeader->getFieldValue()) {
-                throw new ExpectationFailedException($this->createFailureMessage(sprintf(
-                    'Failed asserting response header "%s" DOES NOT CONTAIN "%s"',
-                    $header,
-                    $match
-                )));
-            }
-        }
-
-        $this->assertNotEquals($match, $currentHeader ? $currentHeader->getFieldValue() : null);
+        $expected = [
+            '</style/foo.css>; rel="preload"; nopush',
+            '</style/bar.css>; rel="prefetch"; as="style"; type="text/stylesheet"; nopush',
+            '</style/stylesheet.css>; rel="preload"; as="style"; type="text/css"; media="screen"; nopush',
+            '</script/foo.js>; rel="preload"; as="script"; type="text/javascript"; nopush',
+            '</script/bar.js>; rel="preload"; as="script"; type="text/text"; nopush',
+        ];
+        $this->assertResponseHeaderContains('Link', \implode(', ', $expected));
     }
 }

--- a/tests/Listener/LinkHandlerTest.php
+++ b/tests/Listener/LinkHandlerTest.php
@@ -6,6 +6,7 @@ use Facile\ZFLinkHeadersModule\OptionsInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Zend\Http\Header\GenericMultiHeader;
+use Zend\Http\Header\HeaderInterface;
 use Zend\Http\Headers;
 use Zend\Http\PhpEnvironment;
 use Zend\Http\Response;
@@ -25,6 +26,175 @@ class LinkHandlerTest extends TestCase
         $headLink->getContainer()->shouldNotBeCalled();
         $response->getHeaders()->shouldNotBeCalled();
         $event->getResponse()->willReturn($response->reveal());
+
+        $injector = new LinkHandler($headLink->reveal(), $options->reveal());
+
+        $injector($event->reveal());
+    }
+
+    public function testInvokeWithNoItems()
+    {
+        $links = [];
+
+        $headLink = $this->prophesize(HeadLink::class);
+        $options = $this->prophesize(OptionsInterface::class);
+        $event = $this->prophesize(MvcEvent::class);
+        $responseHeaders = $this->prophesize(Headers::class);
+        $headContainer = $this->prophesize(AbstractContainer::class);
+        $response = $this->prophesize(PhpEnvironment\Response::class);
+
+        $options->isHttp2PushEnabled()->willReturn(false);
+
+        $headContainer->getIterator()->willReturn(new \ArrayIterator($links));
+
+        $headLink->getContainer()->willReturn($headContainer->reveal());
+        $response->getHeaders()->willReturn($responseHeaders->reveal());
+        $event->getResponse()->willReturn($response->reveal());
+
+        $responseHeaders->addHeader(Argument::any())
+            ->shouldNotBeCalled();
+
+        $injector = new LinkHandler($headLink->reveal(), $options->reveal());
+
+        $injector($event->reveal());
+    }
+
+    public function testInvokeWithAnotherExistingHeader()
+    {
+        $links = [
+            $this->createStdClass([
+                'rel' => OptionsInterface::MODE_PRELOAD,
+                'href' => '/foo.css',
+            ]),
+            $this->createStdClass([
+                'rel' => OptionsInterface::MODE_PREFETCH,
+                'href' => '/bar.css',
+                'as' => 'style',
+                'crossorigin' => 'same-origin',
+                'type' => 'text/style',
+                'media' => '(min-width: 100px)',
+                'nopush' => 'nopush',
+            ]),
+            $this->createStdClass([
+                'rel' => OptionsInterface::MODE_DNS_PREFETCH,
+                'href' => '/foo-dns-prefetch.css',
+            ]),
+            $this->createStdClass([
+                'rel' => OptionsInterface::MODE_PRECONNECT,
+                'href' => '/foo-preconnect.css',
+            ]),
+            $this->createStdClass([
+                'rel' => OptionsInterface::MODE_PRERENDER,
+                'href' => '/foo-prerender.css',
+            ]),
+        ];
+
+        $expected = [
+            '</existing-link>; as="style"',
+            '</foo.css>; rel="preload"; nopush',
+            '</bar.css>; rel="prefetch"; as="style"; crossorigin="same-origin"; type="text/style"; media="(min-width: 100px)"; nopush',
+            '</foo-dns-prefetch.css>; rel="dns-prefetch"; nopush',
+            '</foo-preconnect.css>; rel="preconnect"; nopush',
+            '</foo-prerender.css>; rel="prerender"; nopush',
+        ];
+
+        $headLink = $this->prophesize(HeadLink::class);
+        $options = $this->prophesize(OptionsInterface::class);
+        $event = $this->prophesize(MvcEvent::class);
+        $responseHeaders = $this->prophesize(Headers::class);
+        $headContainer = $this->prophesize(AbstractContainer::class);
+        $response = $this->prophesize(PhpEnvironment\Response::class);
+        $existingHeader = $this->prophesize(HeaderInterface::class);
+
+        $options->isHttp2PushEnabled()->willReturn(false);
+
+        $headContainer->getIterator()->willReturn(new \ArrayIterator($links));
+
+        $headLink->getContainer()->willReturn($headContainer->reveal());
+        $response->getHeaders()->willReturn($responseHeaders->reveal());
+        $event->getResponse()->willReturn($response->reveal());
+
+        $responseHeaders->get('Link')->willReturn($existingHeader->reveal());
+        $responseHeaders->removeHeader($existingHeader->reveal())->shouldBeCalled();
+        $existingHeader->getFieldValue()->willReturn('</existing-link>; as="style"');
+
+        $responseHeaders->addHeader(Argument::allOf(
+            Argument::type(GenericMultiHeader::class),
+            Argument::which('getFieldName', 'Link'),
+            Argument::which('getFieldValue', \implode(', ', $expected))
+        ))
+            ->shouldBeCalledTimes(1);
+
+        $injector = new LinkHandler($headLink->reveal(), $options->reveal());
+
+        $injector($event->reveal());
+    }
+
+    public function testInvokeWithAnotherExistingMultiHeader()
+    {
+        $links = [
+            $this->createStdClass([
+                'rel' => OptionsInterface::MODE_PRELOAD,
+                'href' => '/foo.css',
+            ]),
+            $this->createStdClass([
+                'rel' => OptionsInterface::MODE_PREFETCH,
+                'href' => '/bar.css',
+                'as' => 'style',
+                'crossorigin' => 'same-origin',
+                'type' => 'text/style',
+                'media' => '(min-width: 100px)',
+                'nopush' => 'nopush',
+            ]),
+            $this->createStdClass([
+                'rel' => OptionsInterface::MODE_DNS_PREFETCH,
+                'href' => '/foo-dns-prefetch.css',
+            ]),
+            $this->createStdClass([
+                'rel' => OptionsInterface::MODE_PRECONNECT,
+                'href' => '/foo-preconnect.css',
+            ]),
+            $this->createStdClass([
+                'rel' => OptionsInterface::MODE_PRERENDER,
+                'href' => '/foo-prerender.css',
+            ]),
+        ];
+
+        $expected = [
+            '</existing-link>; as="style"',
+            '</foo.css>; rel="preload"; nopush',
+            '</bar.css>; rel="prefetch"; as="style"; crossorigin="same-origin"; type="text/style"; media="(min-width: 100px)"; nopush',
+            '</foo-dns-prefetch.css>; rel="dns-prefetch"; nopush',
+            '</foo-preconnect.css>; rel="preconnect"; nopush',
+            '</foo-prerender.css>; rel="prerender"; nopush',
+        ];
+
+        $headLink = $this->prophesize(HeadLink::class);
+        $options = $this->prophesize(OptionsInterface::class);
+        $event = $this->prophesize(MvcEvent::class);
+        $responseHeaders = $this->prophesize(Headers::class);
+        $headContainer = $this->prophesize(AbstractContainer::class);
+        $response = $this->prophesize(PhpEnvironment\Response::class);
+        $existingHeader = $this->prophesize(HeaderInterface::class);
+
+        $options->isHttp2PushEnabled()->willReturn(false);
+
+        $headContainer->getIterator()->willReturn(new \ArrayIterator($links));
+
+        $headLink->getContainer()->willReturn($headContainer->reveal());
+        $response->getHeaders()->willReturn($responseHeaders->reveal());
+        $event->getResponse()->willReturn($response->reveal());
+
+        $responseHeaders->get('Link')->willReturn(new \ArrayIterator([$existingHeader->reveal()]));
+        $responseHeaders->removeHeader($existingHeader->reveal())->shouldBeCalled();
+        $existingHeader->getFieldValue()->willReturn('</existing-link>; as="style"');
+
+        $responseHeaders->addHeader(Argument::allOf(
+            Argument::type(GenericMultiHeader::class),
+            Argument::which('getFieldName', 'Link'),
+            Argument::which('getFieldValue', \implode(', ', $expected))
+        ))
+            ->shouldBeCalledTimes(1);
 
         $injector = new LinkHandler($headLink->reveal(), $options->reveal());
 
@@ -61,6 +231,14 @@ class LinkHandlerTest extends TestCase
             ]),
         ];
 
+        $expected = [
+            '</foo.css>; rel="preload"; nopush',
+            '</bar.css>; rel="prefetch"; as="style"; crossorigin="same-origin"; type="text/style"; media="(min-width: 100px)"; nopush',
+            '</foo-dns-prefetch.css>; rel="dns-prefetch"; nopush',
+            '</foo-preconnect.css>; rel="preconnect"; nopush',
+            '</foo-prerender.css>; rel="prerender"; nopush',
+        ];
+
         $headLink = $this->prophesize(HeadLink::class);
         $options = $this->prophesize(OptionsInterface::class);
         $event = $this->prophesize(MvcEvent::class);
@@ -76,36 +254,15 @@ class LinkHandlerTest extends TestCase
         $response->getHeaders()->willReturn($responseHeaders->reveal());
         $event->getResponse()->willReturn($response->reveal());
 
+        $responseHeaders->get('Link')->willReturn(false);
+        $responseHeaders->removeHeader(Argument::any())->shouldNotBeCalled();
+
         $responseHeaders->addHeader(Argument::allOf(
             Argument::type(GenericMultiHeader::class),
             Argument::which('getFieldName', 'Link'),
-            Argument::which('getFieldValue', '</foo.css>; rel="preload"; nopush')
+            Argument::which('getFieldValue', \implode(', ', $expected))
         ))
-            ->shouldBeCalled();
-        $responseHeaders->addHeader(Argument::allOf(
-            Argument::type(GenericMultiHeader::class),
-            Argument::which('getFieldName', 'Link'),
-            Argument::which('getFieldValue', '</bar.css>; rel="prefetch"; as="style"; crossorigin="same-origin"; type="text/style"; media="(min-width: 100px)"; nopush')
-        ))
-            ->shouldBeCalled();
-        $responseHeaders->addHeader(Argument::allOf(
-            Argument::type(GenericMultiHeader::class),
-            Argument::which('getFieldName', 'Link'),
-            Argument::which('getFieldValue', '</foo-dns-prefetch.css>; rel="dns-prefetch"; nopush')
-        ))
-            ->shouldBeCalled();
-        $responseHeaders->addHeader(Argument::allOf(
-            Argument::type(GenericMultiHeader::class),
-            Argument::which('getFieldName', 'Link'),
-            Argument::which('getFieldValue', '</foo-preconnect.css>; rel="preconnect"; nopush')
-        ))
-            ->shouldBeCalled();
-        $responseHeaders->addHeader(Argument::allOf(
-            Argument::type(GenericMultiHeader::class),
-            Argument::which('getFieldName', 'Link'),
-            Argument::which('getFieldValue', '</foo-prerender.css>; rel="prerender"; nopush')
-        ))
-            ->shouldBeCalled();
+            ->shouldBeCalledTimes(1);
 
         $injector = new LinkHandler($headLink->reveal(), $options->reveal());
 
@@ -119,6 +276,10 @@ class LinkHandlerTest extends TestCase
                 'rel' => OptionsInterface::MODE_PRELOAD,
                 'href' => '/foo.css',
             ]),
+        ];
+
+        $expected = [
+            '</foo.css>; rel="preload"',
         ];
 
         $headLink = $this->prophesize(HeadLink::class);
@@ -136,12 +297,15 @@ class LinkHandlerTest extends TestCase
         $response->getHeaders()->willReturn($responseHeaders->reveal());
         $event->getResponse()->willReturn($response->reveal());
 
+        $responseHeaders->get('Link')->willReturn(false);
+        $responseHeaders->removeHeader(Argument::any())->shouldNotBeCalled();
+
         $responseHeaders->addHeader(Argument::allOf(
             Argument::type(GenericMultiHeader::class),
             Argument::which('getFieldName', 'Link'),
-            Argument::which('getFieldValue', '</foo.css>; rel="preload"')
+            Argument::which('getFieldValue', \implode(', ', $expected))
         ))
-            ->shouldBeCalled();
+            ->shouldBeCalledTimes(1);
 
         $injector = new LinkHandler($headLink->reveal(), $options->reveal());
 
@@ -160,6 +324,10 @@ class LinkHandlerTest extends TestCase
             ]),
         ];
 
+        $expected = [
+            '</foo.css>; rel="preload"',
+        ];
+
         $headLink = $this->prophesize(HeadLink::class);
         $options = $this->prophesize(OptionsInterface::class);
         $event = $this->prophesize(MvcEvent::class);
@@ -175,12 +343,15 @@ class LinkHandlerTest extends TestCase
         $response->getHeaders()->willReturn($responseHeaders->reveal());
         $event->getResponse()->willReturn($response->reveal());
 
+        $responseHeaders->get('Link')->willReturn(false);
+        $responseHeaders->removeHeader(Argument::any())->shouldNotBeCalled();
+
         $responseHeaders->addHeader(Argument::allOf(
             Argument::type(GenericMultiHeader::class),
             Argument::which('getFieldName', 'Link'),
-            Argument::which('getFieldValue', '</foo.css>; rel="preload"')
+            Argument::which('getFieldValue', \implode(', ', $expected))
         ))
-            ->shouldBeCalled();
+            ->shouldBeCalledTimes(1);
 
         $injector = new LinkHandler($headLink->reveal(), $options->reveal());
 
@@ -202,6 +373,10 @@ class LinkHandlerTest extends TestCase
             ]),
         ];
 
+        $expected = [
+            '</foo.css>; rel="preload"',
+        ];
+
         $headLink = $this->prophesize(HeadLink::class);
         $options = $this->prophesize(OptionsInterface::class);
         $event = $this->prophesize(MvcEvent::class);
@@ -217,12 +392,15 @@ class LinkHandlerTest extends TestCase
         $response->getHeaders()->willReturn($responseHeaders->reveal());
         $event->getResponse()->willReturn($response->reveal());
 
+        $responseHeaders->get('Link')->willReturn(false);
+        $responseHeaders->removeHeader(Argument::any())->shouldNotBeCalled();
+
         $responseHeaders->addHeader(Argument::allOf(
             Argument::type(GenericMultiHeader::class),
             Argument::which('getFieldName', 'Link'),
-            Argument::which('getFieldValue', '</foo.css>; rel="preload"')
+            Argument::which('getFieldValue', \implode(', ', $expected))
         ))
-            ->shouldBeCalled();
+            ->shouldBeCalledTimes(1);
 
         $injector = new LinkHandler($headLink->reveal(), $options->reveal());
 

--- a/tests/view/layout.phtml
+++ b/tests/view/layout.phtml
@@ -10,8 +10,8 @@
     ?>
     <?=
     $this->headScript()
-        ->prependFile('/script/foo.js')
-        ->prependFile('/script/bar.js', 'text/text')
+        ->appendFile('/script/foo.js')
+        ->appendFile('/script/bar.js', 'text/text')
     ?>
 </head>
 <body>


### PR DESCRIPTION
`Link` header is not handled by Zend Framework, and mutiple headers are not allowed.

Now just one header will be injected.