### PR TITLE
Use Throwable interface on ExceptionInterface

### DIFF
--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Facile\ZFLinkHeadersModule\Exception;
 
-interface ExceptionInterface
+interface ExceptionInterface extends \Throwable
 {
 }


### PR DESCRIPTION
Hi guys, 
I think we should use/implement `\Throwable` in `ExceptionInterface`